### PR TITLE
Adjsut runtime configuration for webClientId in GoogleSignIn_Configure

### DIFF
--- a/Plugins/iOS/GoogleSignIn.h
+++ b/Plugins/iOS/GoogleSignIn.h
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 #import <GoogleSignIn/GIDSignIn.h>
-#import <GoogleSignIn/GIDConfiguration.h>
 
 @interface GoogleSignInHandler : NSObject
 {
-    @public
-    GIDConfiguration* signInConfiguration;
-
     @public
     NSString* loginHint;
     

--- a/Plugins/iOS/GoogleSignIn.mm
+++ b/Plugins/iOS/GoogleSignIn.mm
@@ -18,6 +18,7 @@
 #import <GoogleSignIn/GIDGoogleUser.h>
 #import <GoogleSignIn/GIDProfileData.h>
 #import <GoogleSignIn/GIDSignIn.h>
+#import <GoogleSignIn/GIDConfiguration.h>
 #import <GoogleSignIn/GIDToken.h>
 #import <UnityAppController.h>
 
@@ -184,14 +185,11 @@ bool GoogleSignIn_Configure(void *unused, bool useGameSignIn,
                             bool requestIdToken, bool hidePopups,
                             const char **additionalScopes, int scopeCount,
                             const char *accountName) {
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
-    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:path];
-    NSString *clientId = [dict objectForKey:@"CLIENT_ID"];
-    GIDConfiguration* config = [[GIDConfiguration alloc] initWithClientID:clientId];
     if (webClientId) {
-      config = [[GIDConfiguration alloc] initWithClientID:clientId serverClientID:[NSString stringWithUTF8String:webClientId]];
+      NSLog(@"Configure webClientId at runtime");
+      GIDConfiguration* config = [GIDSignIn sharedInstance].configuration;
+      [GIDSignIn sharedInstance].configuration = [[GIDConfiguration alloc] initWithClientID:config.clientId serverClientID:[NSString stringWithUTF8String:webClientId] hostedDomain:config.hostedDomain openIDRealm:config.openIDRealm];
     }
-    [GoogleSignInHandler sharedInstance]->signInConfiguration = config;
 
     int scopeSize = scopeCount;
     if (scopeSize) {

--- a/Plugins/iOS/GoogleSignIn.mm
+++ b/Plugins/iOS/GoogleSignIn.mm
@@ -188,7 +188,7 @@ bool GoogleSignIn_Configure(void *unused, bool useGameSignIn,
     if (webClientId) {
       NSLog(@"Configure webClientId at runtime");
       GIDConfiguration* config = [GIDSignIn sharedInstance].configuration;
-      [GIDSignIn sharedInstance].configuration = [[GIDConfiguration alloc] initWithClientID:config.clientId serverClientID:[NSString stringWithUTF8String:webClientId] hostedDomain:config.hostedDomain openIDRealm:config.openIDRealm];
+      [GIDSignIn sharedInstance].configuration = [[GIDConfiguration alloc] initWithClientID:config.clientID serverClientID:[NSString stringWithUTF8String:webClientId] hostedDomain:config.hostedDomain openIDRealm:config.openIDRealm];
     }
 
     int scopeSize = scopeCount;


### PR DESCRIPTION
Hi,
First I really appreciate your work that help me deal with deprecated package.
I found the configuration logic in iOS platform won't take effect because GoogleSignInHandler.configuration is never accessed and the logic still trying to access client id from old p-list file.
Here is the tiny modification that I think might improve the functionality of GoogleSignIn_Configure in iOS platform.