### PR TITLE
Fix copying NSString for iOS

### DIFF
--- a/Plugins/iOS/GoogleSignIn.mm
+++ b/Plugins/iOS/GoogleSignIn.mm
@@ -339,7 +339,7 @@ static size_t CopyNSString(NSString *src, char *dest, size_t len) {
     strncpy(dest, string, len);
     return len;
   }
-  return src ? src.length + 1 : 0;
+  return src ? [src lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + 1 : 0;
 }
 
 size_t GoogleSignIn_GetServerAuthCode(SignInResult *result, char *buf,


### PR DESCRIPTION
I believe NSString is copied wrong. Once there are non-ASCII symbols in username (like Cyrillic), username gots truncated and last symbol is wrong. This fixes the issue for me.