### PR TITLE
Exclude Nintendo Switch platforms from GoogleSignIn assembly

### DIFF
--- a/GoogleSignIn.asmdef
+++ b/GoogleSignIn.asmdef
@@ -1,3 +1,17 @@
 {
-	"name": "GoogleSignin"
+	"name": "GoogleSignin",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [
+        "Switch2",
+        "Switch"
+    ],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
## Summary
Updated the GoogleSignin assembly definition file to exclude Nintendo Switch platforms (`Switch` and `Switch2`) from compilation.
Changes Made
- Added `Switch` and `Switch2` to the `excludePlatforms` array in `GoogleSignin.asmdef`
- This prevents the GoogleSignin assembly from being compiled for Nintendo Switch targets

## Motivation
Nintendo Switch platforms likely don't support Google Sign-In functionality, so excluding these platforms prevents compilation errors and reduces unnecessary build overhead when targeting Switch platforms.

## Testing

1.  Verified Unity project compiles successfully for non-Switch platforms
2.  Confirmed Switch platform builds no longer attempt to compile GoogleSignin assembly
3.  Tested that existing functionality remains unaffected on supported platforms

## Files Modified

`GoogleSignin.asmdef` - Added Switch platform exclusions