### PR TITLE
Fix: Add platform defines for iOS Editor scripts to prevent Android build errors

### DIFF
--- a/GoogleSignIn/Editor/iOS/PostBuildProcessor.cs
+++ b/GoogleSignIn/Editor/iOS/PostBuildProcessor.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && (UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS)
 using System;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
   ## Problem
   Google Sign-In Editor scripts fail to compile on Android-only builds where iOS Build Support is not installed.
   
   Error message:
   `error CS0234: The type or namespace name 'iOS' does not exist in the namespace 'UnityEditor'`
      
   ## Solution
   Wrap `UnityEditor.iOS.Xcode` imports and iOS-specific code with platform defines:
   ```csharp
   #if UNITY_EDITOR && (UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS)
   using UnityEditor.iOS.Xcode;
   ...
   #endif
   ```
   
   ## Changes
   - Modified `GoogleSignIn/Editor/iOS/PostBuildProcessor.cs`
   - Added `#if UNITY_EDITOR && (UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS)` wrapper
   - Ensures compilation only when iOS Build Support is installed
   
   ## Testing
   - ✅ Tested on Android-only CI environment (no iOS Build Support)
   - ✅ Tested on local machine with both Android and iOS Build Support
   - ✅ iOS builds work correctly
   - ✅ Android builds no longer fail with compilation errors
   
   ## Related Issue
   This fixes compilation errors on CI/CD pipelines that only have Android Build Support installed.