### PR TITLE
Fix iOS build compatibility with Unity 6

### DIFF
--- a/Plugins/iOS/GoogleSignInAppController.mm
+++ b/Plugins/iOS/GoogleSignInAppController.mm
@@ -16,6 +16,7 @@
 
 #import "GoogleSignInAppController.h"
 #import <objc/runtime.h>
+#import <GoogleSignIn/GoogleSignIn.h>
 
 // Handles Google SignIn UI and events.
 GoogleSignInHandler *gsiHandler;
@@ -45,12 +46,15 @@ GoogleSignInHandler *gsiHandler;
       @selector(GoogleSignInAppController:didFinishLaunchingWithOptions:));
   method_exchangeImplementations(original, swizzled);
 
+  // Check if the deprecated method exists before swizzling (Unity < 6)
   original = class_getInstanceMethod(
       self, @selector(application:openURL:sourceApplication:annotation:));
-  swizzled = class_getInstanceMethod(
-      self, @selector
-      (GoogleSignInAppController:openURL:sourceApplication:annotation:));
-  method_exchangeImplementations(original, swizzled);
+  if (original != NULL) {
+    swizzled = class_getInstanceMethod(
+        self, @selector
+        (GoogleSignInAppController:openURL:sourceApplication:annotation:));
+    method_exchangeImplementations(original, swizzled);
+  }
 
   original =
       class_getInstanceMethod(self, @selector(application:openURL:options:));
@@ -65,7 +69,8 @@ GoogleSignInHandler *gsiHandler;
 }
 
 /**
- * Handle the auth URL
+ * Handle the auth URL (deprecated in iOS 9, removed in Unity 6+)
+ * This method is only used if it exists in UnityAppController (Unity < 6)
  */
 - (BOOL)GoogleSignInAppController:(UIApplication *)application
                           openURL:(NSURL *)url
@@ -80,7 +85,7 @@ GoogleSignInHandler *gsiHandler;
 }
 
 /**
- * Handle the auth URL.
+ * Handle the auth URL (modern API, iOS 9+)
  */
 - (BOOL)GoogleSignInAppController:(UIApplication *)app
                           openURL:(NSURL *)url


### PR DESCRIPTION
## 🎯 Problem

Unity 6 removed the deprecated `application:openURL:sourceApplication:annotation:` method from `UnityAppController`. This method was deprecated since iOS 9 and Unity 6+ no longer includes it.

This caused compilation errors during iOS builds:
```objc
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_UnityAppController", referenced from:
       objc-class-ref in GoogleSignInAppController.o
```

## ✅ Solution

This PR fixes the issue by:

1. **Runtime method detection** - Check if the deprecated method exists before attempting to swizzle it
2. **Missing import** - Add `#import <GoogleSignIn/GoogleSignIn.h>` to fix `GIDSignIn` not found error
3. **Backward compatibility** - Maintain support for Unity 5.x through Unity 2022.x

### Changes

**`Plugins/iOS/GoogleSignInAppController.mm`:**
- Added `#import <GoogleSignIn/GoogleSignIn.h>` (line 19)
- Added runtime check for deprecated method existence (lines 49-57):
  ```objc
  // Check if the deprecated method exists before swizzling (Unity < 6)
  original = class_getInstanceMethod(
      self, @selector(application:openURL:sourceApplication:annotation:));
  if (original != NULL) {
    swizzled = class_getInstanceMethod(
        self, @selector
        (GoogleSignInAppController:openURL:sourceApplication:annotation:));
    method_exchangeImplementations(original, swizzled);
  }
  ```

### How it works

- **Unity 5.x - 2022.x**: `application:openURL:sourceApplication:annotation:` exists → swizzling works as before
- **Unity 6.0+**: Method doesn't exist → swizzling is skipped, uses modern `application:openURL:options:` API

## 🧪 Tested

- ✅ Unity 2022.3.x (iOS 13+) - Google Sign-In works correctly
- ✅ Unity 6000.0.58f1 (iOS 15+) - Google Sign-In works correctly
- ✅ No compilation errors on both versions
- ✅ OAuth flow completes successfully on physical iOS devices

## 📚 Related

This is a follow-up to #[previous PR number] which fixed Android compilation issues with Unity 6.

## 🔗 References

- [Unity 6 iOS API changes](https://docs.unity3d.com/6000.0/Documentation/Manual/ios.html)
- [Apple Docs: Deprecated openURL:sourceApplication:annotation:](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623073-application)